### PR TITLE
Updated enter keypress

### DIFF
--- a/src/messenger-shortcuts.js
+++ b/src/messenger-shortcuts.js
@@ -54,10 +54,10 @@ document.body.onkeydown = function(event) {
       break;
     case 77:  // M
       mute();
-      break;    
+      break;
     case 81:  // Q
       focusSearchBar();
-      break;    
+      break;
     case 191: // Fwd. slash
       openHelp();
       break;
@@ -86,7 +86,7 @@ function jumpToMessage(index) {
 }
 
 function selectFirstSearchResult() {
-  var first = document.querySelector('span[role="search"] a');
+  var first = document.querySelector('span[role="option"] a');
   if (first) {
     first.click();
     // focus message input afterwards in case the user already has that chat open


### PR DESCRIPTION
messenger.com now supports searching messages for text, which means the way search results are represented is different. With this PR, Enter should select the first result in the list.

[WIP] Shift+Enter should trigger searching all messages for the text entered.