### PR TITLE
Merge Chrome and Firefox repositories, Search box fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Keyboard Shortcuts for Messenger
 
-This Chrome extension adds keyboard shortcuts to the [Messenger web app](http://messenger.com).
+This Firefox add-on adds keyboard shortcuts to the [Messenger web app](http://messenger.com).
 
-To install, head over to the [Chrome Web Store](https://chrome.google.com/webstore/detail/keyboard-shortcuts-for-me/elgfaolomlhhmppjdicpgpmglkllebfb?hl=en-US&gl=US).
-Alternatively, you can clone this repo and load the `src/` directory as an [unpacked extension](https://developer.chrome.com/extensions/getstarted#unpacked).
+To install, head over to the [Firefox Extension Store](https://addons.mozilla.org/en-US/firefox/addon/keyboardshortcutsformessenger/).
+Alternatively, you can clone this repo and load the `src/` directory as a [temporary add-on](https://developer.mozilla.org/en-US/docs/Tools/about%3Adebugging#Enabling_add-on_debugging).
 
 We now have an official fork for Firefox! Check it out [here](https://github.com/sarangjo/messenger-shortcuts).
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This Firefox add-on adds keyboard shortcuts to the [Messenger web app](http://me
 To install, head over to the [Firefox Extension Store](https://addons.mozilla.org/en-US/firefox/addon/keyboardshortcutsformessenger/).
 Alternatively, you can clone this repo and load the `src/` directory as a [temporary add-on](https://developer.mozilla.org/en-US/docs/Tools/about%3Adebugging#Enabling_add-on_debugging).
 
-We now have an official fork for Firefox! Check it out [here](https://github.com/sarangjo/messenger-shortcuts).
+This add-on was originally designed and developed to be a Chrome extension, and the original source code can be found [here](https://github.com/guoguo12/messenger-shortcuts).
 
 ## List of shortcuts
 ### General

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # Keyboard Shortcuts for Messenger
 
-This Firefox add-on adds keyboard shortcuts to the [Messenger web app](http://messenger.com).
+This Chrome extension/Firefox add-on adds keyboard shortcuts to the [Messenger web app](http://messenger.com).
 
+# Chrome Installation
+To install, head over to the [Chrome Web Store](https://chrome.google.com/webstore/detail/keyboard-shortcuts-for-me/elgfaolomlhhmppjdicpgpmglkllebfb?hl=en-US&gl=US).
+Alternatively, you can clone this repo and load the `src/` directory as an [unpacked extension](https://developer.chrome.com/extensions/getstarted#unpacked).
+
+# Firefox Installation
 To install, head over to the [Firefox Extension Store](https://addons.mozilla.org/en-US/firefox/addon/keyboardshortcutsformessenger/).
 Alternatively, you can clone this repo and load the `src/` directory as a [temporary add-on](https://developer.mozilla.org/en-US/docs/Tools/about%3Adebugging#Enabling_add-on_debugging).
-
-This add-on was originally designed and developed to be a Chrome extension, and the original source code can be found [here](https://github.com/guoguo12/messenger-shortcuts).
 
 ## List of shortcuts
 ### General

--- a/src/messenger-shortcuts.js
+++ b/src/messenger-shortcuts.js
@@ -129,7 +129,13 @@ function focusMessageInput() {
 }
 
 function selectFirstSearchResult() {
-  var contacts = document.querySelectorAll('ul[role="listbox"]')[1];
+  var listboxes = document.querySelectorAll('ul[role="listbox"]');
+  // Checking if only a single character has been pressed
+  var contacts = listboxes[(getSearchBar().value.length() <= 1) ? 0 : 1];
+    contacts = document.querySelector('ul[role="listbox"]');
+  } else {
+    contacts = document.querySelectorAll('ul[role="listbox"]')[1];
+  }
   var first = contacts.querySelector('ul[role="listbox"] li div');
   if (first) {
     click(first);
@@ -149,8 +155,7 @@ function toggleInfo() {
 }
 
 function getSearchBar() {
-  return document.querySelector('input[type="text"][placeholder="Search Messenger"]');
-  // return getByAttr('input', 'type', 'text');
+  return getByAttr('input', 'type', 'text');
 }
 
 function focusSearchBar() {

--- a/src/messenger-shortcuts.js
+++ b/src/messenger-shortcuts.js
@@ -130,12 +130,8 @@ function focusMessageInput() {
 
 function selectFirstSearchResult() {
   var listboxes = document.querySelectorAll('ul[role="listbox"]');
-  // Checking if only a single character has been pressed
-  var contacts = listboxes[(getSearchBar().value.length() <= 1) ? 0 : 1];
-    contacts = document.querySelector('ul[role="listbox"]');
-  } else {
-    contacts = document.querySelectorAll('ul[role="listbox"]')[1];
-  }
+  // Checking if only <= single character has been pressed
+  var contacts = listboxes[(getSearchBar().value.length <= 1) ? 0 : 1];
   var first = contacts.querySelector('ul[role="listbox"] li div');
   if (first) {
     click(first);


### PR DESCRIPTION
- Since the source code is identical, I think it would be nice to have a common repository for both, with the README having instructions for installation on either platform!
- Facebook recently added a "Search in Messages" option at the top of the search bar on the left, so the search + enter functionality was not working. This should be fixed with this pull request.