### PR TITLE
Search bar fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Keyboard Shortcuts for Messenger
 
-This Chrome extension adds keyboard shortcuts to the [Messenger web app](http://messenger.com).
+This Firefox add-on adds keyboard shortcuts to the [Messenger web app](http://messenger.com).
 
-To install, head over to the [Chrome Web Store](https://chrome.google.com/webstore/detail/keyboard-shortcuts-for-me/elgfaolomlhhmppjdicpgpmglkllebfb?hl=en-US&gl=US).
-Alternatively, you can clone this repo and load the `src/` directory as an [unpacked extension](https://developer.chrome.com/extensions/getstarted#unpacked).
+To install, head over to the [Firefox Extension Store](https://addons.mozilla.org/en-US/firefox/addon/keyboardshortcutsformessenger/).
+Alternatively, you can clone this repo and load the `src/` directory as a [temporary add-on](https://developer.mozilla.org/en-US/docs/Tools/about%3Adebugging#Enabling_add-on_debugging).
 
 We now have an official fork for Firefox! Check it out [here](https://github.com/sarangjo/messenger-shortcuts).
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This Firefox add-on adds keyboard shortcuts to the [Messenger web app](http://me
 To install, head over to the [Firefox Extension Store](https://addons.mozilla.org/en-US/firefox/addon/keyboardshortcutsformessenger/).
 Alternatively, you can clone this repo and load the `src/` directory as a [temporary add-on](https://developer.mozilla.org/en-US/docs/Tools/about%3Adebugging#Enabling_add-on_debugging).
 
-We now have an official fork for Firefox! Check it out [here](https://github.com/sarangjo/messenger-shortcuts).
+This add-on was originally designed and developed to be a Chrome extension, and the original source code can be found [here](https://github.com/guoguo12/messenger-shortcuts).
 
 ## List of shortcuts
 ### General

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # Keyboard Shortcuts for Messenger
 
-This Firefox add-on adds keyboard shortcuts to the [Messenger web app](http://messenger.com).
+This Chrome extension/Firefox add-on adds keyboard shortcuts to the [Messenger web app](http://messenger.com).
 
+# Chrome Installation
+To install, head over to the [Chrome Web Store](https://chrome.google.com/webstore/detail/keyboard-shortcuts-for-me/elgfaolomlhhmppjdicpgpmglkllebfb?hl=en-US&gl=US).
+Alternatively, you can clone this repo and load the `src/` directory as an [unpacked extension](https://developer.chrome.com/extensions/getstarted#unpacked).
+
+# Firefox Installation
 To install, head over to the [Firefox Extension Store](https://addons.mozilla.org/en-US/firefox/addon/keyboardshortcutsformessenger/).
 Alternatively, you can clone this repo and load the `src/` directory as a [temporary add-on](https://developer.mozilla.org/en-US/docs/Tools/about%3Adebugging#Enabling_add-on_debugging).
-
-This add-on was originally designed and developed to be a Chrome extension, and the original source code can be found [here](https://github.com/guoguo12/messenger-shortcuts).
 
 ## List of shortcuts
 ### General

--- a/src/messenger-shortcuts.js
+++ b/src/messenger-shortcuts.js
@@ -129,7 +129,8 @@ function focusMessageInput() {
 }
 
 function selectFirstSearchResult() {
-  var first = document.querySelector('ul[role="listbox"] li div');
+  var contacts = document.querySelectorAll('ul[role="listbox"]')[1];
+  var first = contacts.querySelector('ul[role="listbox"] li div');
   if (first) {
     click(first);
   }
@@ -148,7 +149,8 @@ function toggleInfo() {
 }
 
 function getSearchBar() {
-  return getByAttr('input', 'type', 'text');
+  return document.querySelector('input[type="text"][placeholder="Search Messenger"]');
+  // return getByAttr('input', 'type', 'text');
 }
 
 function focusSearchBar() {


### PR DESCRIPTION
Facebook recently added a "Search in Messages" option at the top of the search bar on the left, so the Enter functionality was malfunctioning. This should be fixed with this pull request.